### PR TITLE
improvement: allow assigning initialPossibleTypesMap for SSR use cases

### DIFF
--- a/src/fragmentMatcher.js
+++ b/src/fragmentMatcher.js
@@ -85,7 +85,10 @@ const strategies = {
 
 export class ProgressiveFragmentMatcher {
   constructor (options) {
-    const { strategy: name } = { ...defaultOptions, ...options }
+    const { strategy: name, initialPossibleTypesMap } = {
+      ...defaultOptions,
+      ...options
+    }
 
     if (!strategies[name]) {
       const strategyNames = Object.keys(strategies)
@@ -100,7 +103,7 @@ export class ProgressiveFragmentMatcher {
     const strategy = strategies[name]
 
     // initiate type map.
-    this.possibleTypesMap = {}
+    this.possibleTypesMap = initialPossibleTypesMap || {}
     this.match = this.match.bind(this)
 
     // set strategy based methods.


### PR DESCRIPTION
Hi, awesome library here! This library helped us to fetch instropection data on runtime to avoid loading them upfront on initial load.

We found that there is an issue when doing SSR. The SSR works and we can inject the serialised cache to the client side properly. But, upon hydrating, it seems like the client fails because it doesn't actually know about the `possibleTypes` information yet. We believe this is because the `possibleTypes` is still empty on the client side.

This PR adds a way to give an `initialPossibleTypesMap` to the fragment matcher.